### PR TITLE
fix: `request_every_sec` is missing latest state

### DIFF
--- a/src/bind.rs
+++ b/src/bind.rs
@@ -276,9 +276,10 @@ impl<T: 'static, E: 'static> Bind<T, E> {
         T: MaybeSend,
         E: MaybeSend,
     {
+        let state = self.get_state();
         let since_completed = self.since_completed_raw();
 
-        if self.get_state() != State::Pending && since_completed > secs {
+        if state != State::Pending && since_completed > secs {
             self.request(f());
         }
 


### PR DESCRIPTION
[`request_every_sec`](https://github.com/xangelix/egui-async/blob/501e38f0f28dede8f1b6587edc2ddbc5eb1a7b84/src/bind.rs#L273) has a missing state. It gets `since_completed` without `poll`ing the latest state before. 

The bug is visible by running the `periodic` example: `cargo run --example periodic`

## Before
Two requests within 10 secs. which ends up with three name changes (instead of two): Paul Flores -> Gabe Carlson -> Irene Lopez 

[egui-async-before.webm](https://github.com/user-attachments/assets/f409d646-4908-4c94-a9bb-6249e55da732)


## Fix
Note: One request within 10 secs. with two name changes only (as expected): Cecil Sims -> Adrian Elliott

[egui-async-fixed.webm](https://github.com/user-attachments/assets/c613f661-ad41-4636-b1bd-9e1f22ec0ca5)
